### PR TITLE
[barrett_hand_gazebo] Fix order of add_library and catkin_package

### DIFF
--- a/barrett_hand_gazebo/CMakeLists.txt
+++ b/barrett_hand_gazebo/CMakeLists.txt
@@ -20,14 +20,14 @@ find_package(gazebo REQUIRED)
 link_directories(${GAZEBO_LIBRARY_DIRS})
 include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS} ${GAZEBO_INCLUDE_DIRS})
 
-add_library(gazebo_mimic_plugin src/mimic_plugin.cpp)
-target_link_libraries(gazebo_mimic_plugin ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
-
 catkin_package(
   DEPENDS 
     roscpp 
    gazebo_ros
 )
+
+add_library(gazebo_mimic_plugin src/mimic_plugin.cpp)
+target_link_libraries(gazebo_mimic_plugin ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
 
 install(DIRECTORY launch
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})


### PR DESCRIPTION
This PR makes this package follow https://wiki.ros.org/catkin/CMakeLists.txt#catkin_package.28.29.
This is required for loading gazebo_mimic_plugin when we use `catkin build` to build this package